### PR TITLE
stöplarit yfir verð og laun

### DIFF
--- a/capstone_stoplarit.Rmd
+++ b/capstone_stoplarit.Rmd
@@ -1,0 +1,84 @@
+---
+title: "capstone_grof"
+author: "Þórdís"
+date: "2024-11-06"
+output: html_document
+---
+
+## R Markdown
+
+```{R}
+dat <- Capstone_to_flur
+print(dat)
+```
+
+```{R}
+#REGEX fyrir að breyta íslenskum stöfum í enska fyrir dálkaheitin
+new_names <- gsub("ð", "d", names(dat))
+new_names <- gsub("Ð", "D", new_names)
+new_names <- gsub("þ", "th", new_names)
+new_names <- gsub("Þ", "Th", new_names)
+new_names <- gsub("æ", "ae", new_names)
+new_names <- gsub("Æ", "Ae", new_names)
+new_names <- gsub("ö", "o", new_names)
+new_names <- gsub("Ö", "O", new_names)
+new_names <- gsub("á", "a", new_names)
+new_names <- gsub("Á", "A", new_names)
+new_names <- gsub("é", "e", new_names)
+new_names <- gsub("É", "E", new_names)
+new_names <- gsub("í", "i", new_names)
+new_names <- gsub("Í", "I", new_names)
+new_names <- gsub("ó", "o", new_names)
+new_names <- gsub("Ó", "O", new_names)
+new_names <- gsub("ú", "u", new_names)
+new_names <- gsub("Ú", "U", new_names)
+new_names <- gsub("ý", "y", new_names)
+new_names <- gsub("Ý", "Y", new_names)
+
+
+names(dat) <- new_names
+```
+
+```{R}
+# REGEX fyrir að taka út NA gildi
+filtered_dat <- dat[
+  grepl("^[0-9]+(\\.[0-9]+)?$", dat$`Fermetraverd eftir sveitafelogum arid 2022`) &
+  grepl("^[0-9]+(\\.[0-9]+)?$", dat$`Midgildi tekna 2023`), 
+]
+
+# REGEX til að breyta í töluleg gildi 
+filtered_dat$`Fermetraverd eftir sveitafelogum arid 2022` <- as.numeric(filtered_dat$`Fermetraverd eftir sveitafelogum arid 2022`)
+filtered_dat$`Midgildi tekna 2023` <- as.numeric(filtered_dat$`Midgildi tekna 2023`)
+
+# REGEX til að setja gildin í hækkandi röð
+filtered_dat <- filtered_dat[order(filtered_dat$`Fermetraverd eftir sveitafelogum arid 2022`), ]
+filtered_dat <- filtered_dat %>%
+  arrange(`Fermetraverd eftir sveitafelogum arid 2022`)
+
+```
+
+```{R}
+# Hlaða inn ggplot2 pakkanum
+library(ggplot2)
+
+# Búa til stuðlarit með stærstu gildunum fyrst
+ggplot(filtered_dat, aes(x = reorder(`...1`, -`Fermetraverd eftir sveitafelogum arid 2022`), 
+                         y = `Fermetraverd eftir sveitafelogum arid 2022`)) +
+  geom_col(fill = "darkgreen") +
+  labs(x = "Sveitarfélag", y = "Verð", title = "Stuðlarit: fermetraverð eftir sveitafélögum í þúsundum króna") +
+  theme_minimal() +
+  theme(axis.text.x = element_text(angle = 45, hjust = 1, size = 6))
+```
+
+```{R}
+# Hlaða inn ggplot2 pakkanum
+library(ggplot2)
+
+# Búa til stuðlarit með stærstu gildunum fyrst
+ggplot(filtered_dat, aes(x = reorder(`...1`, -`Midgildi tekna 2023`), 
+                         y = `Midgildi tekna 2023`)) +
+  geom_col(fill = "darkblue") +
+  labs(x = "Sveitarfélag", y = "Miðgildi launa", title = "Stuðlarit: Miðgildi launa eftir sveitafélögum í þúsundum króna") +
+  theme_minimal() +
+  theme(axis.text.x = element_text(angle = 45, hjust = 1, size = 6))
+```


### PR DESCRIPTION
Er með regex segðir til að filtera út strengi, tóm gildi, breyta gildunum i tölugildi og lika til að gildin séu i hækkandi röð.

Er síðan með tvö gröf með fermetra verði eftir sveitafélögum i hækkandi röð og miðgildi launa i hækkandi röð.